### PR TITLE
p -> span because we can't have paragraphs inside paragraphs

### DIFF
--- a/utils/templates/binary-operation.hbs
+++ b/utils/templates/binary-operation.hbs
@@ -1,1 +1,1 @@
-<p>{{left}} to be {{verb}} {{right}}</p>
+<span class="segment">{{left}} to be {{verb}} {{right}}</span>

--- a/utils/templates/conditional.hbs
+++ b/utils/templates/conditional.hbs
@@ -1,1 +1,1 @@
-<p>conditionally use {{trueExpression}} if {{condition}}, otherwise {{falseExpression}}</p>
+<span class="segment">conditionally use {{trueExpression}} if {{condition}}, otherwise {{falseExpression}}</span>

--- a/utils/templates/function-call.hbs
+++ b/utils/templates/function-call.hbs
@@ -1,1 +1,1 @@
-<p>call function <span class="color1">{{name}}</span> {{#if args.length}}with arguments {{#each args}}<span class="color2">{{this}}</span>{{#unless @last}}, {{/unless}}{{/each}}{{/if}}</p>
+<span class="segment">call function <span class="color1">{{name}}</span> {{#if args.length}}with arguments {{#each args}}<span class="color2">{{this}}</span>{{#unless @last}}, {{/unless}}{{/each}}{{/if}}</span>

--- a/utils/templates/function-definition.hbs
+++ b/utils/templates/function-definition.hbs
@@ -1,5 +1,5 @@
-<p>A function with the name <span class="color1">{{name}}</span> {{#if returnParameters.length}}that returns{{#each returnParameters}} <span class="color2">{{this.name}} ({{this.typeName.name}})</span>{{#unless @last}}, {{/unless}} {{/each}}{{/if}}</p>
-{{#if parameters}}<p>with parameters</p>
+<span class="segment">A function with the name <span class="color1">{{name}}</span> {{#if returnParameters.length}}that returns{{#each returnParameters}} <span class="color2">{{this.name}} ({{this.typeName.name}})</span>{{#unless @last}}, {{/unless}} {{/each}}{{/if}}</span>
+{{#if parameters}}<span class="segment">with parameters</span>
 {{parameters}}
 {{/if}}
 {{#if modifiers}}

--- a/utils/templates/if-statement.hbs
+++ b/utils/templates/if-statement.hbs
@@ -1,3 +1,3 @@
-<p>if {{left}} {{operator}} {{right}} do</p>
-{{#if trueBody}}<p>{{trueBody}}</p>{{/if}}
-{{#if falseBody}}<p>{{#if trueBody}}else, </p>{{/if}}<p>{{falseBody}}</p>{{/if}}
+<span class="segment">if {{left}} {{operator}} {{right}} do</span>
+{{#if trueBody}}<span class="segment">{{trueBody}}</span>{{/if}}
+{{#if falseBody}}<span class="segment">{{#if trueBody}}else, </span>{{/if}}<span class="segment">{{falseBody}}</span>{{/if}}

--- a/utils/templates/modifiers.hbs
+++ b/utils/templates/modifiers.hbs
@@ -1,4 +1,4 @@
-<p>is modified by</p>
+<span class="segment">is modified by</span>
 <ul>
     {{#each modifiers}}
         <li>executing <span class="color1">{{this.name}}</span> {{#if this.arguments.length}}with arguments {{#each this.arguments}}<span class="color2">{{this.name}} {{this.typeDescriptions.typeString}}</span>, {{/each}}{{/if}}</li>

--- a/utils/templates/no-statements.hbs
+++ b/utils/templates/no-statements.hbs
@@ -1,1 +1,1 @@
-<p>has no statements{{#if overrides}}, this function was overwritten and won't do anything{{/if}}.</p>
+<span class="segment">has no statements{{#if overrides}}, this function was overwritten and won't do anything{{/if}}.</span>

--- a/utils/templates/return-statement.hbs
+++ b/utils/templates/return-statement.hbs
@@ -1,1 +1,1 @@
-<p>return <span class="color4">{{expression}}</span></p>
+<span class="segment">return <span class="color4">{{expression}}</span></span>

--- a/utils/templates/statement-require.hbs
+++ b/utils/templates/statement-require.hbs
@@ -1,1 +1,1 @@
-<p>requires that {{name}} {{arguments.0.operator}} than {{arguments.0.rightExpression.name}}</p>
+<span class="segment">requires that {{name}} {{arguments.0.operator}} than {{arguments.0.rightExpression.name}}</span>

--- a/utils/templates/statement-return.hbs
+++ b/utils/templates/statement-return.hbs
@@ -1,1 +1,1 @@
-<p>returns <span class="color3">{{expression.baseExpression.typeString}}</span></p>
+<span class="segment">returns <span class="color3">{{expression.baseExpression.typeString}}</span></span>

--- a/utils/templates/unary-operation.hbs
+++ b/utils/templates/unary-operation.hbs
@@ -1,1 +1,1 @@
-{{operator}}{{subExpression}}
+<span class="segment">{{operator}}{{subExpression}}</span>

--- a/utils/templates/variable-declaration.hbs
+++ b/utils/templates/variable-declaration.hbs
@@ -1,1 +1,1 @@
-<p>{{#if initialValue}}Assigns{{/if}}{{#unless initialValue}}Asserts{{/unless}} variable <span class="color1">{{name}}</span>, of type <span class="color2">{{type}}</span>{{#if initialValue}}, with value {{initialValue}}{{/if}}</p>
+<span class="segment">{{#if initialValue}}Assigns{{/if}}{{#unless initialValue}}Asserts{{/unless}} variable <span class="color1">{{name}}</span>, of type <span class="color2">{{type}}</span>{{#if initialValue}}, with value {{initialValue}}{{/if}}</span>


### PR DESCRIPTION
changes the templates from using `p` to use `span.segment`